### PR TITLE
STUDIO-9060: JSON Schema references to non-primitive types fixed

### DIFF
--- a/src/main/java/org/mule/common/metadata/JSONSchemaMetaDataFieldFactory.java
+++ b/src/main/java/org/mule/common/metadata/JSONSchemaMetaDataFieldFactory.java
@@ -3,11 +3,14 @@ package org.mule.common.metadata;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.lang.String;
 import java.util.Map;
 
 import org.mule.common.metadata.datatype.DataType;
-import org.mule.common.metadata.parser.json.*;
+import org.mule.common.metadata.parser.json.JSONArrayType;
+import org.mule.common.metadata.parser.json.JSONObjectType;
+import org.mule.common.metadata.parser.json.JSONPointerType;
+import org.mule.common.metadata.parser.json.JSONType;
+import org.mule.common.metadata.parser.json.JSONTypeUtils;
 
 /**
  * Created by studio on 18/07/2014.
@@ -77,22 +80,40 @@ public class JSONSchemaMetaDataFieldFactory implements MetaDataFieldFactory {
     }
 
     private void processJSONSchemaArray(JSONArrayType property, String name, List<MetaDataField> metadata){
-        JSONType itemsType = property.getItemsType();
+        AbstractMetaDataModel model = buildJSONArrayMetaDataModel(property);
+        metadata.add(new DefaultMetaDataField(name, new DefaultListMetaDataModel(model)));
 
+    }
+
+    private AbstractMetaDataModel buildJSONArrayMetaDataModel(JSONArrayType property) {
+        AbstractMetaDataModel model = null;
+        JSONType itemsType = property.getItemsType();
         if (itemsType.isJSONPrimitive()) { // Case List<String>
             DataType dataType = getDataType(itemsType);
-            MetaDataModel model = dataType==DataType.UNKNOWN ? new DefaultUnknownMetaDataModel(): new DefaultSimpleMetaDataModel(dataType);
-            metadata.add(new DefaultMetaDataField(name, new DefaultListMetaDataModel(model)));
-        }else {
-            DefaultStructuredMetadataModel model = null;
+            model = dataType == DataType.UNKNOWN ? new DefaultUnknownMetaDataModel() : new DefaultSimpleMetaDataModel(dataType);
+        } else {
             if(itemsType.isJSONPointer()){
-                 model = buildJSONMetaDataModel((JSONObjectType) ((JSONPointerType) itemsType).resolve());
+                model = buildJSONPointerMetaDataModel((JSONPointerType) itemsType);
             }else if (itemsType.isJSONObject()){
-                 model = buildJSONMetaDataModel((JSONObjectType) itemsType);
+                model = buildJSONMetaDataModel((JSONObjectType) itemsType);
             }
-            metadata.add(new DefaultMetaDataField(name, new DefaultListMetaDataModel(model)));
         }
+        return model;
+    }
 
+    private AbstractMetaDataModel buildJSONPointerMetaDataModel(JSONPointerType pointer) {
+        JSONType resolvedType = pointer.resolve();
+        if (resolvedType.isJSONArray()) {
+            return buildJSONArrayMetaDataModel((JSONArrayType) resolvedType);
+        } else if (resolvedType.isJSONObject()) {
+            return buildJSONMetaDataModel((JSONObjectType) resolvedType);
+        } else if (resolvedType.isJSONPointer()) {
+            return buildJSONPointerMetaDataModel((JSONPointerType) resolvedType);
+        } else if (resolvedType.isJSONPrimitive()) {
+            DataType dataType = getDataType(resolvedType);
+            return dataType == DataType.UNKNOWN ? new DefaultUnknownMetaDataModel() : new DefaultSimpleMetaDataModel(dataType);
+        }
+        return null;
     }
 
     private void processJSONSchemaPrimitive(JSONType property, String name, List<MetaDataField> metadata) {

--- a/src/main/java/org/mule/common/metadata/JSONSchemaMetaDataFieldFactory.java
+++ b/src/main/java/org/mule/common/metadata/JSONSchemaMetaDataFieldFactory.java
@@ -6,11 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.mule.common.metadata.datatype.DataType;
-import org.mule.common.metadata.parser.json.JSONArrayType;
-import org.mule.common.metadata.parser.json.JSONObjectType;
-import org.mule.common.metadata.parser.json.JSONPointerType;
-import org.mule.common.metadata.parser.json.JSONType;
-import org.mule.common.metadata.parser.json.JSONTypeUtils;
+import org.mule.common.metadata.parser.json.*;
 
 /**
  * Created by studio on 18/07/2014.

--- a/src/main/java/org/mule/common/metadata/parser/json/JSONPointerType.java
+++ b/src/main/java/org/mule/common/metadata/parser/json/JSONPointerType.java
@@ -63,7 +63,7 @@ public class JSONPointerType implements JSONType
             {
                 url = new URL(baseURI);
                 remoteSchema = getRemoteSchema(url);
-                environment = createSchemaEnv(env, remoteSchema);
+                environment = createSchemaEnv(env, remoteSchema, url);
             }
             catch (MalformedURLException e)
             {
@@ -74,7 +74,7 @@ public class JSONPointerType implements JSONType
                 {
                     urlFile = new URL(contextJsonURL, baseURI);
                     remoteSchema = getRemoteSchema(urlFile);
-                    environment = createSchemaEnv(env, remoteSchema);
+                    environment = createSchemaEnv(env, remoteSchema, urlFile);
                 }
                 catch (MalformedURLException e1)
                 {
@@ -155,9 +155,9 @@ public class JSONPointerType implements JSONType
         return result;
     }
 
-    private SchemaEnv createSchemaEnv(SchemaEnv parentEnv, JSONObject remoteSchema) 
+    private SchemaEnv createSchemaEnv(SchemaEnv parentEnv, JSONObject remoteSchema, URL contextUrl)
     {
-        SchemaEnv environment = new SchemaEnv(parentEnv, remoteSchema);
+        SchemaEnv environment = new SchemaEnv(parentEnv, remoteSchema, contextUrl);
         // register root type in new env
         JSONType rootType = environment.evaluate(remoteSchema);
         environment.addType(HASH, rootType);

--- a/src/main/java/org/mule/common/metadata/parser/json/SchemaEnv.java
+++ b/src/main/java/org/mule/common/metadata/parser/json/SchemaEnv.java
@@ -47,7 +47,12 @@ public class SchemaEnv
 
     public SchemaEnv(JSONObject contextJsonObject, URL contextJsonURL)
     {
-        this(null, contextJsonObject);
+        this(null, contextJsonObject, contextJsonURL);
+    }
+
+    public SchemaEnv(SchemaEnv p, JSONObject contextJsonObject, URL contextJsonURL) 
+    {
+        this(p, contextJsonObject);
         this.contextJsonURL = contextJsonURL;
     }
 
@@ -127,7 +132,7 @@ public class SchemaEnv
                         String type = json.getString(JSONSchemaConstants.TYPE).toLowerCase();
                         if (type.equals(JSONSchemaConstants.ARRAY))
                         {
-                            specifiedType = new JSONArrayType(new SchemaEnv(this, contextJsonObject), json);
+                            specifiedType = new JSONArrayType(new SchemaEnv(this, contextJsonObject, contextJsonURL), json);
                         }
                         else if (type.equals(JSONSchemaConstants.OBJECT))
                         {
@@ -139,7 +144,7 @@ public class SchemaEnv
                             // because JSONObjectType will bind itself into the Schema, and we don't
                             // want those names to be globally visible -- only local visible to the
                             // schema's sub-expressions.
-                            specifiedType = new JSONObjectType(new SchemaEnv(this, contextJsonObject), json);
+                            specifiedType = new JSONObjectType(new SchemaEnv(this, contextJsonObject, contextJsonURL), json);
                         }
                         else
                         {//If the type is a string but not an array nor object
@@ -154,7 +159,7 @@ public class SchemaEnv
                 }
                 else if (json.has(JSONSchemaConstants.PROPERTIES))
                 {
-                    specifiedType = new JSONObjectType(new SchemaEnv(this, contextJsonObject), json);
+                    specifiedType = new JSONObjectType(new SchemaEnv(this, contextJsonObject, contextJsonURL), json);
                 }
                 else if (json.has(JSONSchemaConstants.ENUM))
                 {

--- a/src/test/java/org/mule/common/metadata/test/json/schema/JSONSchemaMetaDataModelTest.java
+++ b/src/test/java/org/mule/common/metadata/test/json/schema/JSONSchemaMetaDataModelTest.java
@@ -1,20 +1,32 @@
 package org.mule.common.metadata.test.json.schema;
 
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.json.JSONObject;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mule.common.metadata.*;
+import org.mule.common.metadata.DefaultListMetaDataModel;
+import org.mule.common.metadata.DefaultSimpleMetaDataModel;
+import org.mule.common.metadata.DefaultStructuredMetadataModel;
+import org.mule.common.metadata.DefaultUnknownMetaDataModel;
+import org.mule.common.metadata.JSONSchemaMetadataModelFactory;
+import org.mule.common.metadata.ListMetaDataModel;
+import org.mule.common.metadata.MetaDataModel;
+import org.mule.common.metadata.StructuredMetaDataModel;
+import org.mule.common.metadata.UnknownMetaDataModel;
 import org.mule.common.metadata.datatype.DataType;
-import org.mule.common.metadata.parser.json.*;
-
-import static org.junit.Assert.*;
-
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
+import org.mule.common.metadata.parser.json.JSONObjectType;
+import org.mule.common.metadata.parser.json.SchemaEnv;
+import org.mule.common.metadata.parser.json.SchemaException;
 
 public class JSONSchemaMetaDataModelTest {
 
@@ -556,6 +568,18 @@ public class JSONSchemaMetaDataModelTest {
 
         Assert.assertThat(model.getFields(), IsCollectionWithSize.hasSize(1));
         Assert.assertThat(model.getFieldByName("myfield").getMetaDataModel().getDataType(), CoreMatchers.is(DataType.INTEGER));
+    }
+    
+    @Test
+    public void testJsonWithRefToArray() throws Exception {
+        URL url = Paths.get("src/test/resources/jsonSchema/jsonSchemaWithRefToArray.json").toUri().toURL();
+        MetaDataModel metaDataModel = modelFactory.buildModel(url);
+        Assert.assertNotNull(metaDataModel);
+        Assert.assertThat(metaDataModel.getDataType(), CoreMatchers.is(DataType.JSON));
+
+        Assert.assertThat(metaDataModel, CoreMatchers.instanceOf(StructuredMetaDataModel.class));
+        StructuredMetaDataModel model = (StructuredMetaDataModel) metaDataModel;
+        Assert.assertEquals(model.getFields().get(1).getMetaDataModel().getDataType(), DataType.LIST);
     }
 
     @Test

--- a/src/test/java/org/mule/common/metadata/test/json/schema/JSONSchemaMetaDataModelTest.java
+++ b/src/test/java/org/mule/common/metadata/test/json/schema/JSONSchemaMetaDataModelTest.java
@@ -579,7 +579,7 @@ public class JSONSchemaMetaDataModelTest {
 
         Assert.assertThat(metaDataModel, CoreMatchers.instanceOf(StructuredMetaDataModel.class));
         StructuredMetaDataModel model = (StructuredMetaDataModel) metaDataModel;
-        Assert.assertEquals(model.getFields().get(1).getMetaDataModel().getDataType(), DataType.LIST);
+        Assert.assertEquals(model.getFieldByName("AccessibilityTypes").getMetaDataModel().getDataType(), CoreMatchers.is(DataType.LIST));
     }
 
     @Test

--- a/src/test/resources/jsonSchema/accessibility_types_code.json
+++ b/src/test/resources/jsonSchema/accessibility_types_code.json
@@ -1,0 +1,17 @@
+{
+  "id": "http://localhost:8000/schemas/v1.2/definitions/common/accessibility_types_code.json#",
+  "description": "Information about the accessibility",
+  "type": "string",
+  "enum": [
+    "AudioCashMachine",
+    "AutomaticDoors",
+    "ChairAccess",
+    "DriveThru",
+    "ExternalRamp",
+    "InductionLoop",
+    "InternalRamp",
+    "LevelAccess",
+    "LowerLevelCounter",
+    "WheelchairAccess"
+  ]
+}

--- a/src/test/resources/jsonSchema/jsonSchemaWithRefToArray.json
+++ b/src/test/resources/jsonSchema/jsonSchemaWithRefToArray.json
@@ -1,0 +1,34 @@
+{
+  "id": "http://localhost:8000/schemas/v1.2/atm.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "ATM",
+  "type": "object",
+  "properties": {
+    "ATMID": {
+      "description": "ATM terminal device identification for the acquirer and the issuer",
+      "$ref": "max_35_text.json"
+    },
+    "AccessibilityTypes": {
+      "description": "Information about the accessibility",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "accessibility_types_code.json"
+      }
+    },
+    "SupportedLanguages": {
+      "description": "Languages that the ATM supports",
+      "type": "array",
+      "items": {
+        "description": "must be ISO 693-2 codes",
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "ATMID",
+    "SupportedLanguages"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/resources/jsonSchema/max_35_text.json
+++ b/src/test/resources/jsonSchema/max_35_text.json
@@ -1,0 +1,7 @@
+{
+  "id": "http://localhost:8000/schemas/v1.2/definitions/common/max_35_text.json#",
+  "description": "maxLength 35 text",
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 35
+}


### PR DESCRIPTION
When JSON Schema references were resolved, it was expected to receive a JSONObject, while in fact, it could be a primitive type, an array, or another reference.