### PR TITLE
MULE-12152: Update Jackson Version for Mule 3.8.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <antlr.version>3.5</antlr.version>
         <junit.version>4.11</junit.version>
+        <jackson2.version>2.6.6</jackson2.version>
         <lib-dir>lib</lib-dir>
         <maven.clean.plugin.version>2.5</maven.clean.plugin.version>
         <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
@@ -121,12 +122,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.3</version>
+            <version>${jackson2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.3</version>
+            <version>${jackson2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>


### PR DESCRIPTION
In order to upgrade to the latest Amazon SDK on Cloudhub, minimum Jackson version required is 2.6.6.